### PR TITLE
Use InvariantCulture in URLs for relations

### DIFF
--- a/JMMServer/PlexAndKodi/Helper.cs
+++ b/JMMServer/PlexAndKodi/Helper.cs
@@ -49,7 +49,7 @@ namespace JMMServer.PlexAndKodi
 
         public static string ConstructSupportImageLink(this IProvider prov, string name)
         {
-            double relation = prov.GetRelation();
+            string relation = prov.GetRelation().ToString(CultureInfo.InvariantCulture);
             return prov.ServerUrl(int.Parse(ServerSettings.JMMServerPort), MainWindow.PathAddressREST + "/GetSupportImage/" + name + "/" + relation);
         }
 
@@ -60,7 +60,7 @@ namespace JMMServer.PlexAndKodi
 
         public static string ConstructThumbLink(this IProvider prov, int type, int id)
         {
-            double relation = prov.GetRelation();
+            string relation = prov.GetRelation().ToString(CultureInfo.InvariantCulture);
             return prov.ServerUrl(int.Parse(ServerSettings.JMMServerPort), MainWindow.PathAddressREST + "/GetThumb/" + type + "/" + id + "/" + relation);
         }
 


### PR DESCRIPTION
This resolves issues such as:
```
Error|ErrorPipeline.Invoke => Bootstrapper.<RequestStartup>b__3_1 => Bootstrapper.onError Nancy Error => Request URL:  http://192.168.1.59:8111/JMMServerREST/GetSupportImage/plex_episodes.png/0,6667
Error|ErrorPipeline.Invoke => Bootstrapper.<RequestStartup>b__3_1 => Bootstrapper.onError System.ArgumentException: Parameter is not valid.
```

Which can occur when the system's default NumberFormat isn't en-US.