### PR TITLE
Add some further API endpoints.

### DIFF
--- a/JMMServer/API/Module/apiv2/Common.cs
+++ b/JMMServer/API/Module/apiv2/Common.cs
@@ -102,6 +102,7 @@ namespace JMMServer.API.Module.apiv2
             Get["/ep/vote"] = x => { return VoteOnEpisode(); };
             Get["/ep/unsort"] = _ => { return GetUnsort(); };
             Post["/ep/scrobble"] = x => { return EpisodeScrobble(); };
+            Get["/ep/getbyfilename"] = x => { return GetEpisodeFromName(); };
             #endregion
 
             #region 7. Episodes - [Obsolete]
@@ -890,6 +891,17 @@ namespace JMMServer.API.Module.apiv2
             {
                 return GetEpisodeById(para.id, user.JMMUserID);
             }
+        }
+
+        private object GetEpisodeFromName()
+        {
+            JMMUser user = (JMMUser)this.Context.CurrentUser;
+            string filename = this.Context.Request.Query.filename;
+            if (String.IsNullOrEmpty(filename)) return new Nancy.Response { StatusCode = HttpStatusCode.BadRequest };
+
+            AnimeEpisode aep =RepoFactory.AnimeEpisode.GetByFilename(filename);
+            return new Episode().GenerateFromAnimeEpisode(aep, user.JMMUserID, 0);
+
         }
  
         /// <summary>

--- a/JMMServer/API/Module/apiv2/Common.cs
+++ b/JMMServer/API/Module/apiv2/Common.cs
@@ -1414,16 +1414,23 @@ namespace JMMServer.API.Module.apiv2
             }
         }
 
+        /// <summary>
+        /// Join a string like string.Join but 
+        /// </summary>
+        /// <param name="seperator"></param>
+        /// <param name="values"></param>
+        /// <param name="replaceinvalid"></param>
+        /// <returns></returns>
         internal string Join(string seperator, IEnumerable<string> values, bool replaceinvalid)
         {
             if (!replaceinvalid) return string.Join(seperator, values);
             List<string> newItems = new List<string>();
    
-            string regexSearch = new string(Path.GetInvalidFileNameChars()) + new string(Path.GetInvalidPathChars());
+            string regexSearch = new string(Path.GetInvalidFileNameChars()) + new string(Path.GetInvalidPathChars()) + "()!.?@#$%^&*~";
             Regex r = new Regex(string.Format("[{0}]", Regex.Escape(regexSearch))); 
 
             foreach (string s in values)
-                newItems.Add(r.Replace(s, ""));
+                newItems.Add(r.Replace(s, "").Replace("-", " "));
 
             return string.Join(seperator, newItems);
         }

--- a/JMMServer/Repositories/Cached/AnimeEpisodeRepository.cs
+++ b/JMMServer/Repositories/Cached/AnimeEpisodeRepository.cs
@@ -101,6 +101,12 @@ namespace JMMServer.Repositories.Cached
             return EpisodeIDs.GetOne(epid);
         }
 
+
+        /// <summary>
+        /// Get the AnimeEpisode 
+        /// </summary>
+        /// <param name="name">The filename of the anime to search for.</param>
+        /// <returns>the AnimeEpisode given the file information</returns>
         public AnimeEpisode GetByFilename(string name)
         {
             return RepoFactory.CrossRef_File_Episode.GetAll()

--- a/JMMServer/Repositories/Cached/AnimeEpisodeRepository.cs
+++ b/JMMServer/Repositories/Cached/AnimeEpisodeRepository.cs
@@ -101,6 +101,14 @@ namespace JMMServer.Repositories.Cached
             return EpisodeIDs.GetOne(epid);
         }
 
+        public AnimeEpisode GetByFilename(string name)
+        {
+            return RepoFactory.CrossRef_File_Episode.GetAll()
+                .Where(a => a.FileName.ToLower() == name.ToLower())
+                .Select(a => GetByAniDBEpisodeID(a.EpisodeID))
+                .FirstOrDefault();
+        }
+
 
         /// <summary>
         /// Get all the AnimeEpisode records associate with an AniDB_File record


### PR DESCRIPTION
What this does is add some further information allowed via apiv2, functions are as follows:

*Fuzzy search*: Allows for a search that ignores characters by the following rules.
This applies on `/api/serie/search` as the flag `?fuzzy=true` defaulting to false.
* Invalid path characters + `()+`: are removed.
* Regex: `[ ]{2,}` (more than one consecutive spaces) are removed.
* `-.`: replaced with spaces as media mangers like plex will do this.

I am utilising above for: [ShokoMetadata.bundle](https://github.com/Cazzar/ShokoMetadata.bundle)

*Search episode by filename*
Exposed as `/api/ep/getbyfilename?filename=...`
Allows for searching for the AnimeEpisode reference from the filename on disk.