### PR TITLE
Add episode number prefixes for PHT and the Windows 10 client.

### DIFF
--- a/JMMServer/PlexAndKodi/Helper.cs
+++ b/JMMServer/PlexAndKodi/Helper.cs
@@ -298,6 +298,14 @@ namespace JMMServer.PlexAndKodi
                 {
                     v.ParentIndex = null;
                 }
+
+                if (e.Key.EpisodeTypeEnum == enEpisodeType.Episode)
+                {
+                    string client = prov.GetPlexClient().Product;
+                    if (client == "Plex for Windows" || client == "Plex Home Theater")
+                        v.Title = $"{v.EpisodeNumber}. {v.Title}";
+                }
+
                 if (cross != null && cross.Count > 0)
                 {
                     Contract_CrossRef_AniDB_TvDBV2 c2 =


### PR DESCRIPTION
This closes japanesemediamanager/ShokoOnPlex#37
and resolves japanesemediamanager/ShokoOnPlex#30

![applicationframehost_2017-01-19_00-47-21](https://cloud.githubusercontent.com/assets/994214/22067777/c801bcc2-dde6-11e6-8e25-4feedb75279f.png)


Currently unaware on if this happens on iOS, as I have no devices to test on.