### PR TITLE
Fix renamer when file don't need a rename

### DIFF
--- a/JMMServer/JMMServiceImplementation.cs
+++ b/JMMServer/JMMServiceImplementation.cs
@@ -8251,6 +8251,7 @@ namespace JMMServer
                                             "Renaming file SKIPPED, no change From ({0}) to ({1})",
                                             fullFileName, newFullName));
                                         ret.NewFileName = newFullName;
+                                        name = Path.GetFileName(newFullName);
                                     }
                                     else
                                     {


### PR DESCRIPTION
Prevent empty filename for VideoLocal when the file don't need to be rename

This is link to issues 505 of ShokoClient