### PR TITLE
Remove MinLength and MaxLength from TmdbBulkSearchBody

### DIFF
--- a/Shoko.Server/API/v3/Models/TMDB/Input/TmdbBulkSearchBody.cs
+++ b/Shoko.Server/API/v3/Models/TMDB/Input/TmdbBulkSearchBody.cs
@@ -17,6 +17,6 @@ public class TmdbBulkSearchBody
     /// will take care of the de-duplication before fetching it remotely from
     /// TMDB.
     /// </remarks>
-    [Required, MinLength(1), MaxLength(25)]
+    [Required]
     public List<int> IDs { get; set; } = [];
 }


### PR DESCRIPTION
To fix issues with 'movie' entires like Digimon Tri. (>25)