### PR TITLE
docs: update CLAUDE.md (#1318) [no ci]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Two variants in `Shoko.Server/Repositories/`:
 
 Always prefer a cached repository over a direct one when both exist for the same entity.
 
-**Access pattern**: Repositories are accessed via the `RepoFactory` static class (e.g., `RepoFactory.AnimeSeries.GetByID(id)`). `RepoFactory` is DI-registered but exposes static fields for convenience — this is a legacy pattern similar to `Utils.ServiceContainer`.
+**Access pattern**: Repositories are accessed via the `RepoFactory` static class (e.g., `RepoFactory.AnimeSeries.GetByID(id)`). `RepoFactory` is DI-registered but exposes static fields for convenience — this is a legacy pattern similar to `Utils.ServiceContainer`. This exists for compatibility where DI is unavailable, but DI should be used if possible.
 
 ### Scheduling
 
@@ -170,6 +170,8 @@ All schema migrations and data fixups are in `Shoko.Server/Databases/DatabaseFix
 **`VideoLocal`** is the canonical record for a unique file, identified by its ED2K hash + file size. It holds hashes, `MediaInfo`, import date, and AniDB MyList ID. It does not store a path.
 
 **Note:** `VideoLocal.MediaInfo` is serialized using **MessagePack** via a custom NHibernate type (`MessagePackConverter<MediaContainer>`), not JSON.
+
+**Note:** `FilterPreset.Expression` and `FilterPreset.SortingExpression` use a custom NHibernate type (`FilterExpressionConverter`) for JSON serialization.
 
 **`VideoLocal_Place`** stores where a `VideoLocal` physically lives: a `ManagedFolderID` + `RelativePath`. One `VideoLocal` can have multiple places (the same file duplicated across folders). The absolute path is computed at runtime as `folder.Path + place.RelativePath`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,9 @@ Target framework: `.NET 10.0`. Configurations: `Debug`, `Release`, `ApiLogging`,
 `.editorconfig` with ReSharper enforcement:
 - Line length: 160 characters
 - Modifier order: `private, protected, public, internal, sealed, new, override, virtual, abstract, static, extern, async, unsafe, volatile, readonly, required, file`
-- `var` when type is apparent; braces on new lines (`csharp_new_line_before_open_brace = all`)
+- **`var` preferred everywhere** — `csharp_style_var_elsewhere`, `csharp_style_var_for_built_in_types`, and `csharp_style_var_when_type_is_apparent` all set to `true` (enforced as warnings in `src/` paths)
+- Braces on new lines (`csharp_new_line_before_open_brace = all`)
+- Naming: `_camelCase` for instance fields, `_camelCase` for static fields, `PascalCase` for methods/classes/properties, `camelCase` for locals/parameters
 
 ## Architecture
 
@@ -25,7 +27,7 @@ Target framework: `.NET 10.0`. Configurations: `Debug`, `Release`, `ApiLogging`,
 
 - **`Shoko.Abstractions`** — NuGet package for plugin authors. Defines the interface contract between the core and plugins (`IPlugin`, `IShokoSeries`, `IShokoEpisode`, `IVideo`, `IUser`, and all service/metadata/video/user interfaces). Only update this when the plugin contract itself needs to change.
 - **`Shoko.Server`** — All implementation: API, database, repositories, services, scheduling, providers, models.
-- **`Shoko.CLI`** — Headless server entry point. Hosts `SystemService` as `IHostedService`.
+- **`Shoko.CLI`** — Headless server entry point. Instantiates and manages `SystemService` directly.
 - **`Shoko.TrayService`** — Cross-platform tray app (Avalonia) embedding the server. Runs on Windows, Linux, and macOS.
 - **`Plugins/`** — Built-in plugins (`ReleaseExporter`, `RelocationPlus`, `OfflineImporter`) built as separate projects and loaded at runtime.
 - **`Shoko.Tests`** — Unit tests.
@@ -35,7 +37,11 @@ Target framework: `.NET 10.0`. Configurations: `Debug`, `Release`, `ApiLogging`,
 
 ### Startup Sequence
 
+Entry points: `Shoko.CLI/Program.cs` (headless) or `Shoko.TrayService/Program.cs` (tray app). Both instantiate `new SystemService()` directly, which internally builds and starts the `IHost`.
+
 `Program.cs` → `SystemService` constructor (NLog, `PluginManager`, `ConfigurationService`, `SettingsProvider`) → `SystemService.StartAsync()` (builds and starts `IHost` / ASP.NET Core on port 8111) → `SystemService.LateStart()` (DB migrations via `DatabaseFixes`, init Quartz scheduler, UDP connection handler, file watchers).
+
+**Note:** `LateStart()` is skipped during first-run setup mode (`InSetupMode == true`). It runs either on normal startup or when `CompleteSetup()` transitions out of setup mode.
 
 Global service container is exposed via `Utils.ServiceContainer = _webHost.Services` for legacy code that predates DI,
 and should not be used for new code unless DI is not an option and only as a last resort.
@@ -69,7 +75,9 @@ and should not be used for new code unless DI is not an option and only as a las
 - During first-run setup, `InitUser` (synthetic admin) is used — no real auth required
 - No cookie sessions; every request is authenticated by API key
 
-**API versioning**: `v0` (version-less: auth + legacy Plex webhooks), `v1` (legacy REST, off by default), `v2` (legacy REST, can be kill-switched), `v3` (current, all new endpoints). Version can be resolved from query string, `api-version` header, or custom `ShokoApiReader`. `ApiVersionControllerFeatureProvider` excludes disabled versions at startup via individual flags (`EnableAPIv1`, `EnableAPIv2`, `EnableAPIv3`, `EnableLegacyPlexAPI`, `EnableAuthAPI`).
+**API versioning**: `v0` (version-less: auth + legacy Plex webhooks + index redirect), `v1` (legacy REST, off by default), `v2` (legacy REST, can be kill-switched), `v3` (current, all new endpoints). Version can be resolved from query string, `api-version` header, or custom `ShokoApiReader`. `ApiVersionControllerFeatureProvider` excludes disabled versions at startup via individual flags (`EnableAPIv1`, `EnableAPIv2`, `EnableAPIv3`, `EnableLegacyPlexAPI`, `EnableAuthAPI`).
+
+**Serialization**: MVC uses `AddNewtonsoftJson()` (not `System.Text.Json`) with: `MaxDepth = 10`, `DefaultContractResolver`, `NullValueHandling.Include`, `DefaultValueHandling.Populate`. SignalR also uses `AddNewtonsoftJsonProtocol()`.
 
 Plugin controllers are registered via `AddPluginControllers` during API setup.
 
@@ -119,13 +127,37 @@ Two variants in `Shoko.Server/Repositories/`:
 
 Always prefer a cached repository over a direct one when both exist for the same entity.
 
+**Access pattern**: Repositories are accessed via the `RepoFactory` static class (e.g., `RepoFactory.AnimeSeries.GetByID(id)`). `RepoFactory` is DI-registered but exposes static fields for convenience — this is a legacy pattern similar to `Utils.ServiceContainer`.
+
 ### Scheduling
 
 Quartz.NET with a custom in-memory `ThreadPooledJobStore` (`Shoko.Server/Scheduling/`). Jobs in `Jobs/` are DI-resolved via `JobFactory`. `QueueStateEventHandler` fires domain events (job added/started/completed) consumed by `QueueEventEmitter` → SignalR clients. `DatabaseLocks/` provides named locks to prevent concurrent conflicting DB operations.
 
+**Note:** Quartz is referenced as local DLLs from `Dependencies/Quartz/` (not a NuGet package), using a custom/forked build.
+
 ### Plugin System
 
 `PluginManager` scans the `/plugins/` directory, loads assemblies, finds `IPlugin` implementations via reflection, and registers their services via `RegisterPlugins(IServiceCollection)`. `InitPlugins()` instantiates the plugins after the service container is available. `CorePlugin` is the built-in plugin that ships with the server.
+
+Plugins can also implement `IPluginApplicationRegistration` to register custom middleware via `RegisterServices(IApplicationBuilder, ApplicationPaths)` — invoked during `UseAPI()` after SignalR but before CORS.
+
+Plugin controllers are registered via `AddPluginControllers` during API setup.
+
+### Configuration System
+
+**No `appsettings.json`** exists in the repo. Configuration is code-based:
+- **`ServerSettings`** — primary settings class, persisted to `settings-server.json` via `[StorageLocation]` attribute
+- **`ConfigurationProvider<T>`** — generic provider using `INewtonsoftJsonConfiguration` for JSON serialization
+- **`SettingsProvider`** — singleton accessor (`Utils.SettingsProvider`) for runtime settings access
+- `appsettings.json` is configured as an **optional** overlay in the host builder but is not shipped
+
+### Testing
+
+- **Framework**: xUnit 2.7.0 with `Xunit.DependencyInjection` 9.1.0 for DI in tests
+- **Mocking**: Moq 4.20.70
+- **Coverage**: coverlet 6.0.2
+- **Test SDK**: Microsoft.NET.Test.Sdk 17.9.0
+- Unit tests in `Shoko.Tests/`, integration tests in `Shoko.IntegrationTests/`
 
 ### Database Migrations
 
@@ -136,6 +168,8 @@ All schema migrations and data fixups are in `Shoko.Server/Databases/DatabaseFix
 ### File → Location
 
 **`VideoLocal`** is the canonical record for a unique file, identified by its ED2K hash + file size. It holds hashes, `MediaInfo`, import date, and AniDB MyList ID. It does not store a path.
+
+**Note:** `VideoLocal.MediaInfo` is serialized using **MessagePack** via a custom NHibernate type (`MessagePackConverter<MediaContainer>`), not JSON.
 
 **`VideoLocal_Place`** stores where a `VideoLocal` physically lives: a `ManagedFolderID` + `RelativePath`. One `VideoLocal` can have multiple places (the same file duplicated across folders). The absolute path is computed at runtime as `folder.Path + place.RelativePath`.
 


### PR DESCRIPTION
## 1. `var` preference corrected
**Before:** "`var` when type is apparent"
**After:** "`var` preferred everywhere" with all three editorconfig settings listed

**Why:** The `.editorconfig` sets `csharp_style_var_elsewhere`, `csharp_style_var_for_built_in_types`, and `csharp_style_var_when_type_is_apparent` all to `true` (enforced as warnings in `src/` paths). The original phrasing implied a narrower preference than what's actually enforced.

---

## 2. Added naming conventions
**Added:** `_camelCase` for instance/static fields, `PascalCase` for methods/classes/properties, `camelCase` for locals/parameters

**Why:** These are explicitly defined in `.editorconfig` via `dotnet_naming_rule` entries but were missing from the docs.

---

## 3. Fixed `Shoko.CLI` description
**Before:** "Hosts `SystemService` as `IHostedService`"
**After:** "Instantiates and manages `SystemService` directly"

**Why:** `SystemService` does **not** implement `IHostedService`. Both entry points (`Shoko.CLI/Program.cs` and `Shoko.TrayService/Program.cs`) create `new SystemService()` directly, which internally builds and starts the `IHost`.

---

## 4. Added explicit entry point paths to Startup Sequence
**Added:** "Entry points: `Shoko.CLI/Program.cs` (headless) or `Shoko.TrayService/Program.cs` (tray app). Both instantiate `new SystemService()` directly, which internally builds and starts the `IHost`."

**Why:** There is no `Program.cs` in `Shoko.Server/`. The original "Program.cs → ..." was ambiguous about which project's entry point was being referenced.

---

## 5. Added `LateStart()` conditional behavior note
**Added:** "`LateStart()` is skipped during first-run setup mode (`InSetupMode == true`). It runs either on normal startup or when `CompleteSetup()` transitions out of setup mode."

**Why:** `LateStart()` is conditionally called — it's skipped during setup mode and runs either after normal startup or when `CompleteSetup()` is called. This is important context for understanding the startup flow.

---

## 6. Clarified v0 API scope
**Before:** "auth + legacy Plex webhooks"
**After:** "auth + legacy Plex webhooks + index redirect"

**Why:** v0 also includes `IndexRedirectController` (redirects root `/` to WebUI), not just auth and Plex webhooks.

---

## 7. Added Serialization section
**Added:** "MVC uses `AddNewtonsoftJson()` (not `System.Text.Json`) with: `MaxDepth = 10`, `DefaultContractResolver`, `NullValueHandling.Include`, `DefaultValueHandling.Populate`. SignalR also uses `AddNewtonsoftJsonProtocol()`."

**Why:** The entire API pipeline uses Newtonsoft.Json for serialization, not the default `System.Text.Json`. This affects how DTOs should be designed and how serialization behaves — a significant architectural detail that was missing.

---

## 8. Added `RepoFactory` access pattern note
**Added:** "Repositories are accessed via the `RepoFactory` static class (e.g., `RepoFactory.AnimeSeries.GetByID(id)`). `RepoFactory` is DI-registered but exposes static fields for convenience — this is a legacy pattern similar to `Utils.ServiceContainer`."

**Why:** `RepoFactory` uses static fields for repository access (e.g., `RepoFactory.AnimeSeries`), which is a legacy pattern similar to `Utils.ServiceContainer`. This was undocumented but is the primary way repositories are accessed throughout the codebase.

---

## 9. Added Quartz local DLL note
**Added:** "Quartz is referenced as local DLLs from `Dependencies/Quartz/` (not a NuGet package), using a custom/forked build."

**Why:** The `.csproj` references Quartz via `<Reference>` elements with `<HintPath>` pointing to local DLLs in `Dependencies/Quartz/`, not via `<PackageReference>`. This is important for anyone trying to update Quartz or understand the dependency chain.

---

## 10. Added `IPluginApplicationRegistration` plugin extension
**Added:** "Plugins can also implement `IPluginApplicationRegistration` to register custom middleware via `RegisterServices(IApplicationBuilder, ApplicationPaths)` — invoked during `UseAPI()` after SignalR but before CORS."

**Why:** This is a second plugin extension point (beyond `IPlugin`) that allows plugins to register custom middleware. It was undocumented but actively used in `APIExtensions.cs`.

---

## 11. Added Configuration System section
**Added:** New section documenting `ServerSettings`, `ConfigurationProvider<T>`, `SettingsProvider`, `settings-server.json`, and the optional `appsettings.json` overlay.

**Why:** The configuration system is code-based with settings persisted to `settings-server.json` via `[StorageLocation]` attribute. No `appsettings.json` is shipped. This was completely undocumented.

---

## 12. Added Testing section
**Added:** xUnit 2.7.0, Xunit.DependencyInjection 9.1.0, Moq 4.20.70, coverlet 6.0.2, Microsoft.NET.Test.Sdk 17.9.0

**Why:** The testing framework and versions were not documented anywhere in CLAUDE.md.

---

## 13. Added MessagePack serialization note for `VideoLocal.MediaInfo`
**Added:** "`VideoLocal.MediaInfo` is serialized using **MessagePack** via a custom NHibernate type (`MessagePackConverter<MediaContainer>`), not JSON."

**Why:** `VideoLocal.MediaInfo` uses MessagePack serialization (configured in `VideoLocalMap.cs`), not JSON. This is important for anyone working with the `VideoLocal` model or NHibernate mappings.
